### PR TITLE
Fix Ajustar Vagrantfile para o redirecionamento de portas ser transparente independente do sistema operacional #299

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+require 'ffi'
+
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
@@ -53,26 +55,28 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision "shell", inline: $updateServices,
             run: "always"
 
-##### REDIRECIONAMENTO DA PORTA 80 PARA MAC
-#    config.trigger.after [:provision, :up, :reload] do
-#      system('echo "
-#        rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 80 -> 127.0.0.1 port 8080
-#        rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 443 -> 127.0.0.1 port 8443
-#        " | sudo pfctl -ef - > /dev/null 2>&1; echo "==> Fowarding Ports: 80 -> 8080, 443 -> 8443"')
-#    end
-#
-#    config.trigger.after [:halt, :destroy] do
-#        system("sudo pfctl -df /etc/pf.conf > /dev/null 2>&1; echo '==> Removing Port Forwarding'")
-#    end
+    config.trigger.after [:provision, :up, :reload] do
+        if FFI::Platform::IS_LINUX
+            system("sudo iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080")
+        elsif FFI::Platform::IS_MAC
+            system('echo "
+                rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 80 -> 127.0.0.1 port 8080
+                rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 443 -> 127.0.0.1 port 8443
+                " | sudo pfctl -ef - > /dev/null 2>&1;')
+        end
+        system("echo '==> Fowarding Ports: 80 -> 8080, 443 -> 8443'")
+    end
 
-###### REDIRECIONAMENTO DA PORTA 80 PARA LINUX
-# iptables -t nat -A OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080
-
+    config.trigger.after [:halt, :destroy] do
+        if FFI::Platform::IS_LINUX
+            system("sudo iptables -t nat -D OUTPUT -o lo -p tcp --dport 80 -j REDIRECT --to-port 8080")
+        elsif FFI::Platform::IS_MAC
+            system("sudo pfctl -df /etc/pf.conf > /dev/null 2>&1;")
+        end
+        system("echo '==> Removing Port Forwarding'")
+    end
 
     #config.vm.provider :virtualbox do |vb|
     #  vb.gui = true
     #end
 end
-
-
-


### PR DESCRIPTION
Ajustando Vagrantfile para executar os scripts de redirecionamento de portas de acordo com a plataforma
